### PR TITLE
Travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,20 @@ warnings_are_errors: true
 sudo: true
 dist: trusty
 
-script:
-  - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-5 /usr/bin/gcc
-  - gcc --version
 addons:
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
     packages:
-      - gcc-5
-      - g++-5
       - libapparmor-dev
       - libpoppler-cpp-dev
+
+before_script:
+  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+  - sudo apt-get update
+  - sudo apt-get install gcc-5
+  - sudo apt-get install g++-5
+  - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-5 /usr/bin/gcc
+  - gcc --version
+
 
 env:
     global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,15 @@ addons:
 before_install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update
-  - sudo apt-get install gcc-6
-  - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc
+  - sudo apt-get install gcc-5
+  - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-5 /usr/bin/gcc
   #- sudo update-alternatives --query gcc
   - gcc --version
-  - sudo apt-get install g++-6 
-  - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-6 /usr/bin/g++
+  - sudo apt-get install g++-5
+  - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-5 /usr/bin/g++
   - g++ --version
-  - sudo apt-get install gfortran-6
-  - sudo unlink /usr/bin/gfortran && sudo ln -s /usr/bin/gfortran-6 /usr/bin/gfortran
+  - sudo apt-get install gfortran-5
+  - sudo unlink /usr/bin/gfortran && sudo ln -s /usr/bin/gfortran-5 /usr/bin/gfortran
   - gfortran --version
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
       - libpoppler-cpp-dev
 
 before_install:
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update
   - sudo apt-get install gcc-5
   - sudo apt-get install g++-5

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ addons:
     packages:
       - libapparmor-dev
       - libpoppler-cpp-dev
+before_install:
+  #https://gist.github.com/cotsog/3ce84675af0d74438d91
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-get update -qq
+
 env:
     global:
     - R_CHECK_ARGS="--no-build-vignettes"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,19 @@ language: r
 warnings_are_errors: true
 sudo: true
 dist: trusty
+
+script:
+  - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-5 /usr/bin/gcc
+  - gcc --version
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
+      - gcc-5
+      - g++-5
       - libapparmor-dev
       - libpoppler-cpp-dev
-before_install:
-  #https://gist.github.com/cotsog/3ce84675af0d74438d91
-  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  - sudo apt-get update -qq
 
 env:
     global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,11 @@ before_install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update
   - sudo apt-get install gcc-5
-  - sudo apt-get install g++-5
   - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-5 /usr/bin/gcc
   - gcc --version
+  - sudo apt-get install g++-5
+  - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-5 /usr/bin/g++
+  - g++ --version
 
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
 before_install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update
-  - sudo apt-get install gcc-6 
+  - sudo apt-get install gcc-6
   - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc
   #- sudo update-alternatives --query gcc
   - gcc --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ before_install:
   - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-6 /usr/bin/g++
   - g++ --version
   - sudo apt-get install gfortran-6
-  - sudo unlink /usr/bin/gfortrun && sudo ln -s /usr/bin/gfortrun-6 /usr/bin/gfortrun
-  - gfortrun --version
+  - sudo unlink /usr/bin/gfortran && sudo ln -s /usr/bin/gfortran-6 /usr/bin/gfortran
+  - gfortran --version
 
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ before_install:
   - sudo apt-get install g++-6 
   - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-6 /usr/bin/g++
   - g++ --version
+  - sudo apt-get install gfortran-6
+  - sudo unlink /usr/bin/gfortrun && sudo ln -s /usr/bin/gfortrun-6 /usr/bin/gfortrun
+  - gfortrun --version
 
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
       - libapparmor-dev
       - libpoppler-cpp-dev
 
-before_script:
+before_install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
   - sudo apt-get update
   - sudo apt-get install gcc-5

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,13 @@ addons:
 before_install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update
-  - sudo apt-get install gcc-5
-  - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-5 /usr/bin/gcc
+  - sudo update-alternatives --query gcc
+  - sudo apt-get install gcc-6
+  - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc
+  - sudo update-alternatives --query gcc
   - gcc --version
-  - sudo apt-get install g++-5
-  - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-5 /usr/bin/g++
+  - sudo apt-get install g++-6
+  - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-6 /usr/bin/g++
   - g++ --version
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,11 @@ addons:
 before_install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update
-  - sudo apt-get install gcc-6
+  - sudo apt-get install gcc-6 
   - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc
-  - sudo update-alternatives --query gcc
+  #- sudo update-alternatives --query gcc
   - gcc --version
-  - sudo apt-get install g++-6
+  - sudo apt-get install g++-6 
   - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-6 /usr/bin/g++
   - g++ --version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ addons:
 before_install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update
-  - sudo update-alternatives --query gcc
   - sudo apt-get install gcc-6
   - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc
   - sudo update-alternatives --query gcc


### PR DESCRIPTION
To fix #134 

It took quite a lot of trials and errors but the solution I ended up with is to update the version of `gcc`, `g++` and `gfortran` to 5. 

For some reason, `RSpectra` (or maybe `RcppEigen`) can't work with gcc-6 ([Build 409](https://travis-ci.org/quanteda/readtext/builds/400346677), the build terminated because compilation of a package didn't finish within 4MB log-file limit), and I decided to update it to gcc-5. 