### PR TITLE
Read large twitter json file & Travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: r
 warnings_are_errors: true
 sudo: true
-dist: trusty
+dist: xenial
 
 apt_packages:
   - libssh2-1-dev
@@ -12,21 +12,22 @@ matrix:
   include:
     - os: linux
       compiler: gcc
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-6']
-      env:
-        - COMPILER=g++-6
-        - CC=gcc-6
-        - CXX=g++-6
+
+#      addons:
+#        apt:
+#          sources: ['ubuntu-toolchain-r-test']
+#          packages: ['g++-6']
+#      env:
+#        - COMPILER=g++-6
+#        - CC=gcc-6
+#        - CXX=g++-6
         
-before_install:
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 500
-  - mkdir -p ~/.R
-  - echo "VER=-6" > ~/.R/Makevars
-  - echo "Q0M9Z2NjJChWRVIpIC1zdGQ9YzExIApDWFg9ZysrJChWRVIpClNITElCX0NYWExEPWcrKyQoVkVSKQpGQz1nZm9ydHJhbgpGNzc9Z2ZvcnRyYW4K" | base64 -d > ~/.R/Makevars
-  - cat ~/.R/Makevars
+#before_install:
+#  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 500
+#  - mkdir -p ~/.R
+#  - echo "VER=-6" > ~/.R/Makevars
+#  - echo "Q0M9Z2NjJChWRVIpIC1zdGQ9YzExIApDWFg9ZysrJChWRVIpClNITElCX0NYWExEPWcrKyQoVkVSKQpGQz1nZm9ydHJhbgpGNzc9Z2ZvcnRyYW4K" | base64 -d > ~/.R/Makevars
+#  - cat ~/.R/Makevars
 
 # before_install:
 #  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y

--- a/R/get-functions.R
+++ b/R/get-functions.R
@@ -57,9 +57,9 @@ get_json_tweets <- function(path, verbosity = 1, ...) {
     # if (!requireNamespace("streamR", quietly = TRUE))
     #     stop("You must have streamR installed to read Twitter json files.")
     # read raw json data
-    txt <- readLines(path, warn = FALSE, ...)
+    #txt <- readLines(path, warn = FALSE, ...)
     tryCatch({
-        streamR::parseTweets(txt, verbose = FALSE, ...)
+        streamR::parseTweets(path, verbose = FALSE, ...)
     },
         error = function(e) {
         if (verbosity >= 1)


### PR DESCRIPTION
This is a simple bugfix for `get_json_tweets()`. 

Current `master` branch breaks an R-session when the text file is large (I realized that when I try to read a 300MB file). This is because in the current implementation, the function tries to read the entire file with `readLines()` and then pass the text vector to `StreamR::parseTweet()`:
https://github.com/quanteda/readtext/blob/master/R/get-functions.R#L60-L62

This is unnecessary, as `StreamR::parseTweet()` can handle file inputs by directly passing the file path. 

This PR also fixes travis error, by simply switching from Trusty (14.04) to Xenial (16.04). 

Xenial is available since Nov 2018, but somehow I missed the update.
https://blog.travis-ci.com/2018-11-08-xenial-release

Closes #148 
