### PR TITLE
fix for future breaking changes in readODS 1.7

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     httr,
     jsonlite (>= 0.9.10),
     pdftools,
-    readODS,
+    readODS (>= 1.7.0),
     readxl,
     streamR,
     stringi,

--- a/R/get-functions.R
+++ b/R/get-functions.R
@@ -245,7 +245,7 @@ get_excel <- function(path, text_field, docid_field, source, ...) {
 
 
 get_ods <- function(path, text_field, docid_field, source, ...) {
-    sheet_names <- readODS::ods_sheets(path)
+    sheet_names <- readODS::list_ods_sheets(path)
     suppressMessages(
         sheets <- lapply(sheet_names, function(x, ...) readODS::read_ods(path, sheet = x, ...))
     )


### PR DESCRIPTION
Next version of readODS (2.0) will deprecate the function `ods_sheets` for consistency (all function names start with a verb).

In the current CRAN version (just updated to 1.7), `ods_sheets` is still there but with a warning message.

Sorry for the (future) breaking changes.