### PR TITLE
Fix handling of archive files with upper-case extensions (e.g. .DOCX)

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -174,7 +174,7 @@ extract_archive <- function(file, ignore_missing) {
         stop("File '", file, "' does not exist.")
 
     path <- get_temp(directory = TRUE)
-    ext <- tools::file_ext(file)
+    ext <- tolower(tools::file_ext(file))
     if (ext %in% c("zip", "docx", "odt")) {
         utils::unzip(file, exdir = path)
     } else if (ext %in% c("gz", "tar", "bz")) {


### PR DESCRIPTION
In identifying the correct filetype to read, `readtext()` uses `tolower()` on the file extension. But `extract_archive()` doesn't. So if you try to read a file with the extension ".DOCX" it is correctly sent to `extract_archive()`, but that fails with "Archive extension DOCX unrecognised." and the file cannot be read. This trivial PR fixes that.