### PR TITLE
Fix doc

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,5 +42,5 @@ Encoding: UTF-8
 BugReports: https://github.com/quanteda/readtext/issues
 LazyData: TRUE
 VignetteBuilder: knitr
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)

--- a/R/readtext.R
+++ b/R/readtext.R
@@ -92,7 +92,7 @@
 #'   \item 3: output detailed file-related messages
 #' }
 #' @param ... additional arguments passed through to low-level file reading 
-#'   function, such as [file()], [fread()], etc.  Useful 
+#'   function, such as [file()], [data.table::fread()], etc.  Useful 
 #'   for specifying an input encoding option, which is specified in the same was
 #'   as it would be give to [iconv()].  See the Encoding section of 
 #'   [file] for details.  

--- a/man/readtext.Rd
+++ b/man/readtext.Rd
@@ -117,7 +117,7 @@ when \code{file} is a URL.}
 }}
 
 \item{...}{additional arguments passed through to low-level file reading
-function, such as \code{\link[=file]{file()}}, \code{\link[=fread]{fread()}}, etc.  Useful
+function, such as \code{\link[=file]{file()}}, \code{\link[data.table:fread]{data.table::fread()}}, etc.  Useful
 for specifying an input encoding option, which is specified in the same was
 as it would be give to \code{\link[=iconv]{iconv()}}.  See the Encoding section of
 \link{file} for details.}


### PR DESCRIPTION
So that it prevents the WARN generated by the devel version of R

```
  Found the following Rd file(s) with Rd \link{} targets missing package
  anchors:
    readtext.Rd: fread
  Please provide package anchors for all Rd \link{} targets not in the
  package itself and the base packages.
```